### PR TITLE
Fix OpenBSD build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+PROG = ktrigger
+SRCS = ktrigger.c main.c
+NOMAN =
+
+.include <bsd.prog.mk>

--- a/ktrigger.c
+++ b/ktrigger.c
@@ -1,4 +1,7 @@
+#include <sys/types.h>
 #include <sys/event.h>
+#include <sys/time.h>
+
 #include <err.h>
 #include <fcntl.h>
 #include <stdbool.h>


### PR DESCRIPTION
According to OpenBSD kevent(2) manpage, kevent requires these headers to be included:

```C
#include <sys/types.h>
#include <sys/event.h>
#include <sys/time.h>
```

I also added a simple Makefile.